### PR TITLE
Add `application/x-protobuffer` to the list of opaque-blocklisted-never-sniffed MIME types"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ An **opaque-blocklisted-never-sniffed MIME type** is a MIME type whose essence i
 * "`application/vnd.wordprocessing-openxml`"
 * "`application/x-gzip`"
 * "`application/x-protobuf`"
+* "`application/x-protobuffer`"
 * "`application/zip`"
 * "`multipart/byteranges`"
 * "`multipart/signed`"


### PR DESCRIPTION
This mime type is another commonly used mime type that is defined by the protobuf library as an "alternate" mime type:

https://googleapis.dev/java/google-http-client/1.29.0/com/google/api/client/protobuf/ProtocolBuffers.html#ALT_CONTENT_TYPE

It should be equally worth protecting with similar compatibility impact.